### PR TITLE
Allow vite 3.x to use this package

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "prepublishOnly": "run-s build changelog"
   },
   "peerDependencies": {
-    "vite": "^2.1.5 || ^3.0.5",
+    "vite": "^2.1.5 || ^3.0.5"
   },
   "devDependencies": {
     "conventional-changelog-cli": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yfwz100/vite-plugin-vue2-i18n",
-  "version": "1.0.0-2",
+  "version": "1.0.0-3",
   "main": "dist/index.js",
   "files": [
     "dist"
@@ -22,7 +22,7 @@
     "prepublishOnly": "run-s build changelog"
   },
   "peerDependencies": {
-    "vite": "^2.1.5"
+    "vite": "^2.1.5 || ^3.0.5",
   },
   "devDependencies": {
     "conventional-changelog-cli": "^2.1.1",
@@ -30,7 +30,7 @@
     "prettier": "^2.2.1",
     "rimraf": "^3.0.2",
     "typescript": "^4.2.4",
-    "vite": "^2.1.5"
+    "vite": "^3.0.5"
   },
   "prettier": {
     "singleQuote": true,


### PR DESCRIPTION
Thanks for this plugin! I've been using it with vite 3.0.5 just fine besides the need to append `--legacy-peer-deps` to the install because of the peerDependency. I think this should probably fix it (besides updating the dist file) Let me know. Cheers!